### PR TITLE
[FIX] Fix multi module to type-safe

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,21 +43,21 @@ android {
 dependencies {
     implementations(
         // core
-        project(path = ":core:common"),
-        project(path = ":core:data"),
-        project(path = ":core:datastore"),
-        project(path = ":core:design-system"),
-        project(path = ":core:domain"),
-        project(path = ":core:network"),
-        project(path = ":core:ui"),
+        projects.core.common,
+        projects.core.data,
+        projects.core.datastore,
+        projects.core.designSystem,
+        projects.core.domain,
+        projects.core.network,
+        projects.core.ui,
 
         // feature
-        project(path = ":feature:home"),
-        project(path = ":feature:login"),
-        project(path = ":feature:splash"),
-        project(path = ":feature:main"),
-        project(path = ":feature:navigator"),
-        project(path = ":feature:workthrough"),
+        projects.feature.home,
+        projects.feature.login,
+        projects.feature.splash,
+        projects.feature.main,
+        projects.feature.navigator,
+        projects.feature.workthrough,
 
         // library
         libs.androidx.core.ktx,

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -14,10 +14,11 @@ android {
 // Add library
 dependencies {
     implementations(
-        project(path = ":core:common"),
-        project(path = ":core:network"),
-        project(path = ":core:datastore"),
-        project(path = ":core:domain"),
+        projects.core.common,
+        projects.core.network,
+        projects.core.datastore,
+        projects.core.domain,
+
         libs.retrofit.core,
         libs.retrofit.kotlin.serialization,
         libs.kotlinx.serialization.json,

--- a/core/design-system/build.gradle.kts
+++ b/core/design-system/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    setNamespace("core.design_system")
+    setNamespace("core.designSystem")
 }
 
 // Add library

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -19,8 +19,9 @@ android {
 // Add library
 dependencies {
     implementations(
-        project(path = ":core:datastore"),
-        project(path = ":core:domain"),
+        projects.core.datastore,
+        projects.core.domain,
+
         libs.retrofit.core,
         libs.retrofit.kotlin.serialization,
         libs.okhttp3.core,

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 // Add library
 dependencies {
     implementations(
-        project(path = ":core:design-system"),
+        projects.core.designSystem,
 
         libs.androidx.core.ktx,
         libs.androidx.appcompat

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -18,8 +18,9 @@ dependencies {
         libs.androidx.core.ktx,
         libs.kotlinx.serialization.json,
         libs.kakao.auth,
-        project(path = ":feature:navigator"),
-        project(path = ":core:data"),
-        project(path = ":core:domain"),
+
+        projects.feature.navigator,
+        projects.core.data,
+        projects.core.domain,
     )
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementations(
         libs.androidx.core.ktx,
 
-        project(path = ":feature:login"),
-        project(path = ":feature:navigator"),
+        projects.feature.login,
+        projects.feature.navigator,
     )
 }

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -17,8 +17,8 @@ dependencies {
         libs.androidx.core.ktx,
         libs.androidx.splash,
 
-        project(path = ":feature:navigator"),
-        project(path = ":core:data"),
-        project(path = ":core:domain"),
+        projects.feature.navigator,
+        projects.core.data,
+        projects.core.domain,
     )
 }

--- a/feature/workthrough/build.gradle.kts
+++ b/feature/workthrough/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
     implementations(
         libs.androidx.core.ktx,
 
-        project(path = ":feature:navigator"),
+        projects.feature.navigator,
     )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "FitRun-android"
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 pluginManagement {
     includeBuild("build-logic")
     repositories {


### PR DESCRIPTION
- 모듈 간 의존성 설정할 때 string -> type-safe 하게 변경함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Gradle 빌드 스크립트에서 프로젝트 종속성 참조 방식을 더 간결하고 일관된 형태로 개선했습니다.
  * 일부 네임스페이스 표기법이 업데이트되었습니다.

* **Chores**
  * 타입 세이프 프로젝트 접근자 기능이 활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->