### PR TITLE
[FEAT][FITRUN-152] 달리기 전 온보딩 UI: 목표 설정

### DIFF
--- a/feature/running/src/main/kotlin/com/yapp/fitrun/feature/running/runningonboarding/RunningOnBoardingScreen.kt
+++ b/feature/running/src/main/kotlin/com/yapp/fitrun/feature/running/runningonboarding/RunningOnBoardingScreen.kt
@@ -3,43 +3,58 @@ package com.yapp.fitrun.feature.running.runningonboarding
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.yapp.fitrun.core.designsystem.Body_body2_bold
 import com.yapp.fitrun.core.designsystem.Body_body3_medium
+import com.yapp.fitrun.core.designsystem.Body_body3_regular
 import com.yapp.fitrun.core.designsystem.Body_body3_semiBold
 import com.yapp.fitrun.core.designsystem.Body_body4_bold
 import com.yapp.fitrun.core.designsystem.Body_body4_regular
 import com.yapp.fitrun.core.designsystem.Head_h1_bold
+import com.yapp.fitrun.core.designsystem.Head_h2_bold
 import com.yapp.fitrun.feature.running.runningonboarding.viewmodel.RunningOnBoardingState
 import com.yapp.fitrun.feature.running.runningonboarding.viewmodel.RunningOnBoardingViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 import com.yapp.fitrun.core.designsystem.R
+import com.yapp.fitrun.core.designsystem.pretendardFamily
 import com.yapp.fitrun.core.ui.FitRunTextButton
 import com.yapp.fitrun.core.ui.FitRunTextIconButton
 import com.yapp.fitrun.core.ui.NavigationTopAppBar
@@ -110,7 +125,9 @@ internal fun RunningOnBoardingFirstScreen(
             textAlign = TextAlign.Center,
             color = colorResource(R.color.fg_nuetral_gray600),
             style = Body_body3_semiBold,
-            modifier = Modifier.clickable { navigateToReady() }.padding(bottom = 49.dp)
+            modifier = Modifier
+                .clickable { navigateToReady() }
+                .padding(bottom = 49.dp)
         )
     }
 }
@@ -206,7 +223,9 @@ fun GoalButton(
         ),
     ) {
         Column(
-            modifier = Modifier.wrapContentSize().align(Alignment.CenterVertically),
+            modifier = Modifier
+                .wrapContentSize()
+                .align(Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Image(
@@ -238,6 +257,112 @@ fun GoalButton(
     }
 }
 
+@Composable
+internal fun RunningOnBoardingThirdScreen(
+    uiState: RunningOnBoardingState,
+    onBackClick: () -> Unit,
+    navigateToReady: () -> Unit,
+) {
+    val goalValue = remember { mutableStateOf(if (uiState.isShowTimeGoal) "30" else "3") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colorResource(R.color.fg_nuetral_gray1000)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        NavigationTopAppBar(
+            onLeftNavigationClick = onBackClick,
+            onRightNavigationClick = navigateToReady,
+            leftNavigationIconTint = colorResource(R.color.fg_icon_interactive_inverse),
+            rightIconText = stringResource(R.string.running_on_boarding_skip),
+            rightIconColor = colorResource(R.color.fg_text_interactive_secondary),
+            isRightIconVisible = true
+        )
+
+        Text(
+            text = if (uiState.isShowTimeGoal)
+                stringResource(R.string.running_on_boarding_goal_time_title)
+            else
+                stringResource(R.string.running_on_boarding_goal_distance_title),
+            modifier = Modifier.padding(top = 36.dp),
+            textAlign = TextAlign.Center,
+            color = colorResource(R.color.fg_text_interactive_inverse),
+            style = Head_h2_bold,
+        )
+
+        Text(
+            text = if (uiState.isShowTimeGoal)
+                stringResource(R.string.running_on_boarding_goal_time_description)
+            else
+                stringResource(R.string.running_on_boarding_goal_distance_description),
+            modifier = Modifier.padding(top = 12.dp),
+            textAlign = TextAlign.Center,
+            color = colorResource(R.color.fg_nuetral_gray400),
+            style = Body_body3_regular,
+        )
+
+        Row(modifier = Modifier
+            .wrapContentSize()
+            .padding(top = 80.dp)
+        ) {
+            BasicTextField(
+                modifier = Modifier.width(IntrinsicSize.Min),
+                value = goalValue.value,
+                onValueChange = {
+                    goalValue.value = it
+                },
+                textStyle = TextStyle(
+                    textAlign = TextAlign.End,
+                    fontFamily = pretendardFamily,
+                    fontWeight = FontWeight(LocalContext.current.resources.getInteger(R.integer.font_weight_normal_bold)),
+                    fontSize = 52.sp,
+                    color = colorResource(R.color.fg_text_interactive_inverse),
+                    lineHeight = dimensionResource(id = R.dimen.line_height_1700).value.sp,
+                    letterSpacing = dimensionResource(id = R.dimen.number_letter_spacing).value.sp,
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Center,
+                        trim = LineHeightStyle.Trim.None
+                    )
+                ),
+                decorationBox = { innerTextField ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(all = 16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        innerTextField()
+                        Spacer(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(2.dp)
+                                .background(colorResource(R.color.bg_interactive_primary),)
+                        )
+                    }
+                },
+            )
+
+            Text(
+                text = if (uiState.isShowTimeGoal) "분" else "km",
+                modifier = Modifier.align(Alignment.CenterVertically).padding(top = 10.dp),
+                textAlign = TextAlign.Center,
+                color = colorResource(R.color.fg_text_disabled),
+                style = Head_h1_bold,
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        FitRunTextButton(
+            modifier = Modifier.padding(start = 20.dp, end = 20.dp, bottom = 46.dp),
+            onClick = navigateToReady,
+            text = stringResource(R.string.running_on_boarding_set_goal_run)
+        )
+    }
+}
+
+
 @Preview
 @Composable
 fun RunningOnBoardingFirstScreenPreview() {
@@ -257,5 +382,15 @@ fun RunningOnBoardingSecondScreenPreview() {
         navigateToReady = {},
         onBackClick = {},
         navigateToSetGoal = {},
+    )
+}
+
+@Preview
+@Composable
+fun RunningOnBoardingThirdScreenPreview() {
+    RunningOnBoardingThirdScreen(
+        uiState = RunningOnBoardingState(),
+        navigateToReady = {},
+        onBackClick = {},
     )
 }

--- a/feature/running/src/main/kotlin/com/yapp/fitrun/feature/running/runningonboarding/viewmodel/RunningOnBoardingState.kt
+++ b/feature/running/src/main/kotlin/com/yapp/fitrun/feature/running/runningonboarding/viewmodel/RunningOnBoardingState.kt
@@ -1,5 +1,7 @@
 package com.yapp.fitrun.feature.running.runningonboarding.viewmodel
 
 data class RunningOnBoardingState(
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
+    val isShowTimeGoal: Boolean = false,
+    val isShowDistanceGoal: Boolean = false,
 )


### PR DESCRIPTION
- 러닝 온보딩 구현함
- 설정 완료했을 때 lottie 애니메이션 + 시작 lottie 애니메이션 추가 구현 필요
- navigation 작업 및 ViewModel 작업 필요
- 
<img width="2352" height="1297" alt="스크린샷 2025-07-21 오후 9 43 40" src="https://github.com/user-attachments/assets/8a128874-df5d-4b3c-865e-9532fc8e521e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 러닝 온보딩 과정에서 목표(시간 또는 거리)를 입력할 수 있는 신규 화면이 추가되었습니다.
  * 목표 유형에 따라 입력 필드와 단위(분 또는 km)가 다르게 표시됩니다.
  * 기본값이 자동으로 설정되며, 목표 입력 후 진행할 수 있는 버튼이 제공됩니다.

* **개선 사항**
  * 목표 유형별 UI 표시를 제어하는 상태값이 추가되어, 온보딩 과정에서 더욱 유연한 화면 구성이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->