### PR TITLE
[FIX][FITRUN-40] 목표 설정 API 붙이기

### DIFF
--- a/core/data/src/main/kotlin/com/yapp/fitrun/core/data/repository/GoalRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/yapp/fitrun/core/data/repository/GoalRepositoryImpl.kt
@@ -113,7 +113,7 @@ class GoalRepositoryImpl @Inject constructor(
     ): Result<GoalEntity> {
         return runCatching {
             val response = goalDatasource.setWeeklyRunningCountGoal(
-                WeeklyRunCountRequest(count),
+                WeeklyRunCountRequest(count, isRemindEnabled),
             )
             response.result.toEntity()
         }.fold(
@@ -131,7 +131,7 @@ class GoalRepositoryImpl @Inject constructor(
     ): Result<GoalEntity> {
         return runCatching {
             val response = goalDatasource.updateWeeklyRunCountGoal(
-                WeeklyRunCountRequest(count),
+                WeeklyRunCountRequest(count, isRemindEnabled),
             )
             response.result.toEntity()
         }.fold(

--- a/core/network/src/main/kotlin/com/yapp/fitrun/core/network/model/request/goal/WeeklyRunCountRequest.kt
+++ b/core/network/src/main/kotlin/com/yapp/fitrun/core/network/model/request/goal/WeeklyRunCountRequest.kt
@@ -7,4 +7,6 @@ import kotlinx.serialization.Serializable
 data class WeeklyRunCountRequest(
     @SerialName("count")
     val count: Int,
+    @SerialName("remindAlert")
+    val remindAlert: Boolean,
 )

--- a/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/component/RunningCountSection.kt
+++ b/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/component/RunningCountSection.kt
@@ -50,24 +50,31 @@ import com.yapp.fitrun.core.designsystem.R
 import com.yapp.fitrun.core.designsystem.pretendardFamily
 
 @Composable
-fun SetRunningCountSection() {
-    var currentRunningCount by remember { mutableStateOf("") }
+fun SetRunningCountSection(
+    initialCount: Int = 3,
+    isRemindEnabled: Boolean = false,
+    onRunningCountChange: (Int) -> Unit = {},
+    onRemindEnabledChange: (Boolean) -> Unit = {},
+) {
     RunningCountInput(
-        onRunningCountChange = { runningCount ->
-            currentRunningCount = runningCount
-        },
+        initialCount = initialCount,
+        isRemindEnabled = isRemindEnabled,
+        onRunningCountChange = onRunningCountChange,
+        onRemindEnabledChange = onRemindEnabledChange,
     )
 }
 
 @Composable
 fun RunningCountInput(
     modifier: Modifier = Modifier,
-    onRunningCountChange: (String) -> Unit = {},
+    initialCount: Int = 3,
+    isRemindEnabled: Boolean = false,
+    onRunningCountChange: (Int) -> Unit = {},
+    onRemindEnabledChange: (Boolean) -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
-    var runningCountText by remember { mutableStateOf("3") }
-//    var isFocused by remember { mutableStateOf(false) }
-    var isAlarm by remember { mutableStateOf(false) }
+    var runningCountText by remember { mutableStateOf(initialCount.toString()) }
+    var isAlarm by remember { mutableStateOf(isRemindEnabled) }
 
     Column(
         modifier = modifier
@@ -86,13 +93,19 @@ fun RunningCountInput(
         RunningCountTextField(
             value = runningCountText,
             onValueChange = { newValue ->
-                runningCountText = newValue
-                onRunningCountChange(newValue)
+                // 숫자만 허용
+                val filteredValue = newValue.filter { it.isDigit() }
+                // 최대 2자리까지만 허용
+                val limitedValue = filteredValue.take(2)
+                runningCountText = limitedValue
+
+                // 유효한 숫자인 경우에만 콜백 호출
+                limitedValue.toIntOrNull()?.let { count ->
+                    if (count in 1..14) { // 1~14회까지만 허용
+                        onRunningCountChange(count)
+                    }
+                }
             },
-//            isFocused = isFocused,
-//            onFocusChanged = { focused ->
-//                isFocused = focused
-//            },
         )
         Spacer(modifier = Modifier.height(40.dp))
         Row(
@@ -124,11 +137,9 @@ fun RunningCountInput(
                     .clip(RoundedCornerShape(50))
                     .clickable {
                         isAlarm = !isAlarm
+                        onRemindEnabledChange(isAlarm)
                     },
                 checked = isAlarm,
-//                onCheckedChange = {
-//                    isAlarm = it
-//                },
             )
         }
     }
@@ -137,7 +148,6 @@ fun RunningCountInput(
 @Composable
 fun ToggleSwitch(
     checked: Boolean,
-//    onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val switchWidth = 50.dp
@@ -178,8 +188,6 @@ fun ToggleSwitch(
 private fun RunningCountTextField(
     value: String,
     onValueChange: (String) -> Unit,
-//    isFocused: Boolean,
-//    onFocusChanged: (Boolean) -> Unit,
 ) {
     Row(
         modifier = Modifier

--- a/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalEffect.kt
+++ b/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalEffect.kt
@@ -1,5 +1,0 @@
-package com.yapp.fitrun.feature.setgoal.viewmodel
-
-sealed interface SetGoalEffect {
-    data object NavigateTo
-}

--- a/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalSideEffect.kt
+++ b/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalSideEffect.kt
@@ -1,0 +1,8 @@
+package com.yapp.fitrun.feature.setgoal.viewmodel
+
+sealed class SetGoalSideEffect {
+    data class ShowSuccessToast(val message: String) : SetGoalSideEffect()
+    data class ShowErrorToast(val message: String) : SetGoalSideEffect()
+    object NavigateToComplete : SetGoalSideEffect()
+    object ShowCompleteLottie : SetGoalSideEffect()
+}

--- a/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalState.kt
+++ b/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalState.kt
@@ -1,6 +1,14 @@
 package com.yapp.fitrun.feature.setgoal.viewmodel
 
 data class SetGoalState(
-    val goalPace: Long,
-    val goalRunCount: Int,
+    val isLoading: Boolean = false,
+    val isLoadingRecommendPace: Boolean = false,
+    val goalEntity: com.yapp.fitrun.core.domain.entity.GoalEntity? = null,
+    val paceGoal: Int? = null, // 초 단위
+    val weeklyRunCount: Int? = null,
+    val isRemindEnabled: Boolean = false,
+    val recommendPace: Int? = null, // 초 단위
+    val currentPaceInput: Int? = 420, // 7'00" = 420초
+    val currentRunCountInput: Int? = 3,
+    val currentRemindEnabled: Boolean = false,
 )

--- a/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalViewModel.kt
+++ b/feature/setgoal/src/main/java/com/yapp/fitrun/feature/setgoal/viewmodel/SetGoalViewModel.kt
@@ -1,8 +1,206 @@
 package com.yapp.fitrun.feature.setgoal.viewmodel
 
 import androidx.lifecycle.ViewModel
+import com.yapp.fitrun.core.domain.repository.GoalRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
-class SetGoalViewModel @Inject constructor() : ViewModel()
+class SetGoalViewModel @Inject constructor(
+    private val goalRepository: GoalRepository,
+) : ViewModel(), ContainerHost<SetGoalState, SetGoalSideEffect> {
+
+    override val container: Container<SetGoalState, SetGoalSideEffect> = container(SetGoalState())
+
+    fun setPaceGoal(pace: Int) = intent {
+        reduce { state.copy(isLoading = true) }
+
+        goalRepository.setPaceGoal(pace)
+            .onSuccess { goalEntity ->
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        paceGoal = pace,
+                        goalEntity = goalEntity,
+                    )
+                }
+                postSideEffect(SetGoalSideEffect.ShowSuccessToast("페이스 목표가 설정되었습니다"))
+            }
+            .onFailure { error ->
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast(error.message ?: "페이스 설정 중 오류가 발생했습니다"))
+            }
+    }
+
+    fun setWeeklyRunningCountGoal(count: Int, isRemindEnabled: Boolean) = intent {
+        reduce { state.copy(isLoading = true) }
+
+        goalRepository.setWeeklyRunningCountGoal(count, isRemindEnabled)
+            .onSuccess { goalEntity ->
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        weeklyRunCount = count,
+                        isRemindEnabled = isRemindEnabled,
+                        goalEntity = goalEntity,
+                    )
+                }
+                postSideEffect(SetGoalSideEffect.ShowSuccessToast("주간 러닝 목표가 설정되었습니다"))
+            }
+            .onFailure { error ->
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast(error.message ?: "러닝 횟수 설정 중 오류가 발생했습니다"))
+            }
+    }
+
+    fun updatePaceGoal(pace: Int) = intent {
+        reduce { state.copy(isLoading = true) }
+
+        goalRepository.updatePaceGoal(pace)
+            .onSuccess { goalEntity ->
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        paceGoal = pace,
+                        goalEntity = goalEntity,
+                    )
+                }
+                postSideEffect(SetGoalSideEffect.ShowSuccessToast("페이스 목표가 수정되었습니다"))
+            }
+            .onFailure { error ->
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast(error.message ?: "페이스 수정 중 오류가 발생했습니다"))
+            }
+    }
+
+    fun updateWeeklyRunningCountGoal(count: Int, isRemindEnabled: Boolean) = intent {
+        reduce { state.copy(isLoading = true) }
+
+        goalRepository.updateWeeklyRunningCountGoal(count, isRemindEnabled)
+            .onSuccess { goalEntity ->
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        weeklyRunCount = count,
+                        isRemindEnabled = isRemindEnabled,
+                        goalEntity = goalEntity,
+                    )
+                }
+                postSideEffect(SetGoalSideEffect.ShowSuccessToast("주간 러닝 목표가 수정되었습니다"))
+            }
+            .onFailure { error ->
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast(error.message ?: "러닝 횟수 수정 중 오류가 발생했습니다"))
+            }
+    }
+
+    fun getGoal() = intent {
+        reduce { state.copy(isLoading = true) }
+
+        goalRepository.getGoal()
+            .onSuccess { goalEntity ->
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        goalEntity = goalEntity,
+                        paceGoal = goalEntity.paceGoal,
+                        weeklyRunCount = goalEntity.weeklyRunCount,
+                    )
+                }
+            }
+            .onFailure { error ->
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast(error.message ?: "목표 정보를 불러오는 중 오류가 발생했습니다"))
+            }
+    }
+
+    fun getRecommendPace() = intent {
+        reduce { state.copy(isLoadingRecommendPace = true) }
+
+        goalRepository.getRecommendPace()
+            .onSuccess { recommendPace ->
+                reduce {
+                    state.copy(
+                        isLoadingRecommendPace = false,
+                        recommendPace = recommendPace,
+                    )
+                }
+            }
+            .onFailure { error ->
+                reduce { state.copy(isLoadingRecommendPace = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast(error.message ?: "추천 페이스를 불러오는 중 오류가 발생했습니다"))
+            }
+    }
+
+    fun setPaceInUI(pace: Int) = intent {
+        reduce { state.copy(currentPaceInput = pace) }
+    }
+
+    fun setWeeklyRunCountInUI(count: Int) = intent {
+        reduce { state.copy(currentRunCountInput = count) }
+    }
+
+    fun setRemindEnabledInUI(enabled: Boolean) = intent {
+        reduce { state.copy(currentRemindEnabled = enabled) }
+    }
+
+    fun submitGoals() = intent {
+        val paceSeconds = state.currentPaceInput
+        val runCount = state.currentRunCountInput
+        val remindEnabled = state.currentRemindEnabled
+
+        if (paceSeconds == null || runCount == null) {
+            postSideEffect(SetGoalSideEffect.ShowErrorToast("모든 목표를 설정해주세요"))
+            return@intent
+        }
+
+        reduce { state.copy(isLoading = true) }
+
+        // 기존 목표가 있는지 확인
+        if (state.goalEntity != null) {
+            // 업데이트
+            val paceResult = goalRepository.updatePaceGoal(paceSeconds)
+            val countResult = goalRepository.updateWeeklyRunningCountGoal(runCount, remindEnabled)
+
+            if (paceResult.isSuccess && countResult.isSuccess) {
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        paceGoal = paceSeconds,
+                        weeklyRunCount = runCount,
+                        isRemindEnabled = remindEnabled,
+                    )
+                }
+                postSideEffect(SetGoalSideEffect.ShowCompleteLottie)
+            } else {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast("목표 설정 중 오류가 발생했습니다"))
+            }
+        } else {
+            // 새로 설정
+            val paceResult = goalRepository.setPaceGoal(paceSeconds)
+            val countResult = goalRepository.setWeeklyRunningCountGoal(runCount, remindEnabled)
+
+            if (paceResult.isSuccess && countResult.isSuccess) {
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        paceGoal = paceSeconds,
+                        weeklyRunCount = runCount,
+                        isRemindEnabled = remindEnabled,
+                    )
+                }
+                postSideEffect(SetGoalSideEffect.ShowCompleteLottie)
+            } else {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(SetGoalSideEffect.ShowErrorToast("목표 설정 중 오류가 발생했습니다"))
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주간 달성 목표 설정 시 리마인드 알림 기능이 추가되었습니다.
  * 목표 설정 화면에서 페이스, 주간 달성 횟수, 리마인드 알림을 개별적으로 입력 및 변경할 수 있습니다.
  * 목표 설정 완료 시 성공/실패 토스트 메시지와 애니메이션, 완료 화면으로 이동하는 기능이 제공됩니다.

* **개선 및 변경**
  * 목표 설정 화면이 ViewModel 기반으로 개선되어 입력값, 로딩 상태, 애니메이션 등이 더욱 명확하게 동작합니다.
  * 페이스와 주간 달성 횟수 입력 UI가 외부 상태와 동기화되어 입력값이 실시간으로 반영됩니다.
  * 페이스 입력이 3단계(워밍업, 루틴, 챌린지)로 단순화되었습니다.
  * 주간 달성 횟수 입력 시 1~14 범위로 제한되고, 숫자만 입력할 수 있습니다.
  * 리마인드 알림 토글이 즉시 반영됩니다.

* **버그 수정**
  * 목표 설정 중 중복 입력 및 잘못된 값 입력 시의 예외 처리가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->